### PR TITLE
feat(navbar): add navbar for material and custom themes, modify routes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,8 +6,13 @@ import { AboutComponent } from './about/about.component';
 const routes: Routes = [
   {
     path: '',
+    redirectTo: '/home',
+    pathMatch: 'full'
+  },
+  {
+    path: 'home',
     component: AboutComponent,
-    data: { title: 'About' }
+    data: { title: 'Home'}
   },
   {
     path: 'about',

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <!-- Picture & Bio -->
-<app-toolbar [style]="layoutStyle" [pageTitle]="pageTitle"></app-toolbar>
+<!-- <app-toolbar [style]="layoutStyle" [pageTitle]="pageTitle"></app-toolbar> -->
 <div id="parent-container">
   <router-outlet></router-outlet>
 </div>
-<app-footer [style]="layoutStyle" (selectLayoutEvent)="setLayout($event)"></app-footer>
+<!-- <app-footer [style]="layoutStyle" (selectLayoutEvent)="setLayout($event)"></app-footer> -->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <!-- Picture & Bio -->
+<app-toolbar [style]="layoutStyle" [pageTitle]="pageTitle"></app-toolbar>
 <div id="parent-container">
   <router-outlet></router-outlet>
 </div>
-
-<!-- <app-footer [style]="layoutStyle" (selectLayoutEvent)="setLayout($event)"></app-footer> -->
+<app-footer [style]="layoutStyle" (selectLayoutEvent)="setLayout($event)"></app-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,6 +20,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
 
   public layoutStyle: string;
+  public pageTitle: string;
 
   /**
    * @param _ls Handles the layout of the application between either Material Design and the original website design.
@@ -29,6 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
    */
   constructor(private _ls: LayoutService, private _route: ActivatedRoute, private _router: Router, private _ts: Title) { }
   ngOnInit() {
+    this.pageTitle = this._ts.getTitle();
 
     // Subscribe to the router and provide updates to the document title based on the current route.
     this._router.events.pipe(
@@ -45,6 +47,7 @@ export class AppComponent implements OnInit, OnDestroy {
         }
       })
     ).subscribe((pageTitle: string) => {
+      this.pageTitle = pageTitle;
       const fullTitle = `${pageTitle} | Robert Crowdis`;
       this._ts.setTitle(fullTitle);
     });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,12 +10,14 @@ import { SharedModule } from './shared/shared.module';
 import { AppComponent } from './app.component';
 import { FooterComponent } from './footer/footer.component';
 import { AboutComponent } from './about/about.component';
+import { ToolbarComponent } from './toolbar/toolbar.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     FooterComponent,
-    AboutComponent
+    AboutComponent,
+    ToolbarComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+
 
 
 /**
@@ -9,10 +12,12 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 @NgModule({
   imports: [
     CommonModule,
-    MatToolbarModule
+    MatToolbarModule,
+    MatButtonModule
   ],
   exports: [
-    MatToolbarModule
+    MatToolbarModule,
+    MatButtonModule
   ]
 })
 export class MaterialModule { }

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -1,0 +1,20 @@
+<div id="toolbar">
+
+  <!-- Custom Styling -->
+  <div id="custom-toolbar" *ngIf="style === 'custom'">
+    <span class="toolbar-option" [routerLink]="['/', 'home']" routerLinkActive="router-link-active">Home</span>
+    <span class="toolbar-spacer"> | </span>
+    <span class="toolbar-option" [routerLink]="['/', 'work']" routerLinkActive="router-link-active">Work</span>
+    <span class="toolbar-spacer"> | </span>
+    <span class="toolbar-option" [routerLink]="['/', 'about']" routerLinkActive="router-link-active">About</span>
+  </div>
+
+  <!-- Material Styling -->
+  <mat-toolbar id="material-toolbar" *ngIf="style === 'material'">
+    <span>{{pageTitle}}</span>
+    <span class="spacer"></span>
+    <button mat-button [routerLink]="['/', 'home']" routerLinkActive="router-link-active">Home</button>
+    <button mat-button [routerLink]="['/', 'work']" routerLinkActive="router-link-active">Work</button>
+    <button mat-button [routerLink]="['/', 'about']" routerLinkActive="router-link-active">About</button>
+  </mat-toolbar>
+</div>

--- a/src/app/toolbar/toolbar.component.scss
+++ b/src/app/toolbar/toolbar.component.scss
@@ -1,0 +1,39 @@
+#custom-toolbar {
+  height: 64px;
+  width: 100%;
+  color: white;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+
+  .toolbar-option {
+    padding: 8px 12px;
+    transition: color .25s ease-in-out;
+    box-sizing: border-box;
+    &:hover {
+      cursor: pointer;
+      color: orange;
+    }
+  
+    &.router-link-active {
+      border-bottom: 2px solid darkgray;
+    }
+  }
+
+  .toolbar-spacer {
+    margin: auto 20px;
+  }
+}
+
+
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+#material-toolbar {
+  > .router-link-active {
+    background-color: darkgray;
+  }
+}

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ToolbarComponent } from './toolbar.component';
+
+describe('ToolbarComponent', () => {
+  let component: ToolbarComponent;
+  let fixture: ComponentFixture<ToolbarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ToolbarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-toolbar',
+  templateUrl: './toolbar.component.html',
+  styleUrls: ['./toolbar.component.scss']
+})
+export class ToolbarComponent implements OnInit {
+
+  @Input() style: string;
+  @Input() pageTitle: string;
+
+  constructor() { }
+
+  ngOnInit(): void {}
+
+}


### PR DESCRIPTION
Add a working navbar that (currently) is not displayed to the user, but will be used once multiple pages are added to the application!

* fix(app-routing): change base root to redirect to 'home'
* feat(material): add material button import
* fix(title): set pagetitle variable to pass to children in app component
* feat(toolbar): add toolbar component …
   * Has two blueprinted styles: custom and material, that can be interchanged via the 'style'
* chore(navbar): comment out navbar and footer for pr