### PR TITLE
feat(animation): Add animation overlay to swap between Material and my own style of layouts

### DIFF
--- a/src/app/about/about.component.scss
+++ b/src/app/about/about.component.scss
@@ -44,6 +44,9 @@ p > span {
     img {
       margin: auto;
     }
+    section {
+      margin: 30px auto;
+    }
   }
 
   #contact-me {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,13 @@
-<!-- Picture & Bio -->
+<!-- Toolbar -->
 <!-- <app-toolbar [style]="layoutStyle" [pageTitle]="pageTitle"></app-toolbar> -->
+
+<!-- Page Content -->
 <div id="parent-container">
   <router-outlet></router-outlet>
 </div>
+
+<!-- Footer -->
 <!-- <app-footer [style]="layoutStyle" (selectLayoutEvent)="setLayout($event)"></app-footer> -->
+
+<!-- Transition Overlay -->
+<!-- <app-transition [showOverlay]="changingLayout"></app-transition> -->

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,9 +16,10 @@ import { filter, map } from 'rxjs/operators';
 export class AppComponent implements OnInit, OnDestroy {
 
   private _layoutSubscription$: Subscription;
+  private _transitionStateSubscription$: Subscription;
   private _defaultTitle = 'RC';
 
-
+  public changingLayout: boolean;
   public layoutStyle: string;
   public pageTitle: string;
 
@@ -29,6 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
    * @param _ts A service that can be used to get and set the title of a current HTML document.
    */
   constructor(private _ls: LayoutService, private _route: ActivatedRoute, private _router: Router, private _ts: Title) { }
+
   ngOnInit() {
     this.pageTitle = this._ts.getTitle();
 
@@ -56,6 +58,11 @@ export class AppComponent implements OnInit, OnDestroy {
     this._layoutSubscription$ = this._ls.layout.subscribe((layout: string) => {
       this.layoutStyle = layout;
     });
+
+    // Subscribe to the state of animation to pass into the transition component
+    this._transitionStateSubscription$ = this._ls.transitionState.subscribe((isAnimating: boolean) => {
+      this.changingLayout = isAnimating;
+    });
   }
 
   ngOnDestroy() {
@@ -70,4 +77,5 @@ export class AppComponent implements OnInit, OnDestroy {
   public setLayout(layoutStyle: string) {
     this._ls.setLayout(layoutStyle);
   }
+
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,13 +11,15 @@ import { AppComponent } from './app.component';
 import { FooterComponent } from './footer/footer.component';
 import { AboutComponent } from './about/about.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
+import { TransitionComponent } from './transition/transition.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     FooterComponent,
     AboutComponent,
-    ToolbarComponent
+    ToolbarComponent,
+    TransitionComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/core/services/layout.service.ts
+++ b/src/app/core/services/layout.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ReplaySubject } from 'rxjs';
+import { ReplaySubject, BehaviorSubject } from 'rxjs';
 
 
 /**
@@ -11,24 +11,28 @@ import { ReplaySubject } from 'rxjs';
 export class LayoutService {
 
   private _layout$: ReplaySubject<string> = new ReplaySubject<string>();
+  private _transitionState$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor() {
     this.instantiateLayout();
   }
 
-
+  /**
+   * Getter function for the current layout selected by the user.
+   *
+   * @returns Observable that contains a string value with the currently selected layout.
+   */
   get layout() {
     return this._layout$;
   }
 
   /**
-   * Sets a string inside of the browser's local storage session, to save styling between visits of the website.
+   * Getter function for the state of transitioning animation.
    *
-   * @param layoutType String containing 'material' or 'custom'. Default is 'material'
+   * @returns Observable that contains the state of animation happening.
    */
-  public setLayout(layoutType: string): void {
-    localStorage.setItem('layout', layoutType);
-    this._layout$.next(layoutType);
+  get transitionState() {
+    return this._transitionState$;
   }
 
   /**
@@ -45,6 +49,21 @@ export class LayoutService {
       }
       this._layout$.next('custom');
     }
+  }
+
+  /**
+   * Sets a string inside of the browser's local storage session, to save styling between visits of the website.
+   * Also triggers an animation state for the transition to begin.
+   *
+   * @param layoutType String containing 'material' or 'custom'. Default is 'material'.
+   */
+  public setLayout(layoutType: string): void {
+    localStorage.setItem('layout', layoutType);
+    this._transitionState$.next(true);
+    setTimeout(() => {
+      this._layout$.next(layoutType);
+      this._transitionState$.next(false);
+    }, 500);
   }
 
 }

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,10 +1,4 @@
 <div id="footer">
-  <span>Select a style: </span>
-  <span class="layout-option" [ngClass]="{ 'selected': style === 'custom' }"
-    (click)="selectLayout('custom')">Robbie's Layout (default)
-  </span>
-  <span> or </span>
-  <span class="layout-option --unused" [ngClass]="{ 'selected': style === 'material' }">
-    Angular Material (coming soon)
-  </span>
+  <span class="layout-option" *ngIf="style === 'custom'" (click)="selectLayout('material')">Swap to Angular Material</span>
+  <span class="layout-option" *ngIf="style === 'material'" (click)="selectLayout('custom')">Swap to Original Theme</span>
 </div>

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -11,18 +11,18 @@
 .layout-option {
   color: orange;
   cursor: pointer;
-  transition: color .20s ease-in-out;
+  padding: 16px 6px;
+  transition: all .20s ease-in-out;
+  border-radius: 12px;
   &:hover {
     color: darkorange;
-  }
-
-  &.--unused {
-    color: lightgray !important;
-    cursor: not-allowed;
+    background-color: rgba(0,0,0,0.3);
   }
 }
 
-.selected {
-  color: green !important;
-  cursor: default;
+// TODO: Change button styling for mobile users - RC 5/18/20
+@media (max-width: 800px) {
+  #footer {
+    position: relative;
+  }
 }

--- a/src/app/transition/transition.component.html
+++ b/src/app/transition/transition.component.html
@@ -1,0 +1,3 @@
+<div id="transition-overlay" *ngIf="showOverlay" [@fadeAnimation]>
+  <p>(Ein Moment, bitte!)</p>
+</div>

--- a/src/app/transition/transition.component.scss
+++ b/src/app/transition/transition.component.scss
@@ -1,0 +1,19 @@
+#transition-overlay {
+  color: white;
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: black;
+
+  p {
+    font-size: 16px;
+    color: white;
+  }
+}

--- a/src/app/transition/transition.component.spec.ts
+++ b/src/app/transition/transition.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TransitionComponent } from './transition.component';
+
+describe('TransitionComponent', () => {
+  let component: TransitionComponent;
+  let fixture: ComponentFixture<TransitionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TransitionComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TransitionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/transition/transition.component.ts
+++ b/src/app/transition/transition.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { trigger, state, style, transition, animate, sequence } from '@angular/animations';
+
+
+/**
+ * Overlay to display when a user is transitioning between different styles on the website.
+ */
+@Component({
+  selector: 'app-transition',
+  templateUrl: './transition.component.html',
+  styleUrls: ['./transition.component.scss'],
+  animations: [
+    trigger('fadeAnimation', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate(250),
+      ]),
+      transition(':leave', [
+        animate(500, style({ opacity: 1 })),
+        animate(250, style({ opacity: 0 }))
+      ])
+    ])
+  ]
+})
+export class TransitionComponent implements OnInit {
+
+  @Input() showOverlay: boolean;
+
+  constructor() { }
+
+  ngOnInit(): void { }
+
+}


### PR DESCRIPTION
Header and Footer that show off these changes are commented until fully designed in both styles. Has been tested and works under all cases.

* feat(layout): add state for transitioning animations between layouts
* feat(transition): add transition overlay and attach to layout state
* style(about): modify margins for mobile view
* fix(footer): push footer to bottom on mobile, make better UX decisions …
   * Instead of a wall of text at the bottom, the user can simply click to alternate between the two styles (custom and material)